### PR TITLE
Improve compatibility with nix-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,10 +18,13 @@
       mkHM = import ./lib/mk-hm.nix;
       system = "x86_64-linux";
       revision = nixpkgs.lib.mkIf (self ? rev) self.rev;
-      perSystem = flake-utils.lib.eachDefaultSystem (system: {
-        formatter = nixpkgs.legacyPackages.${system}.nixpkgs-fmt;
-        devShell = import ./dev-shell.nix { inherit system nixpkgs; };
-      });
+      perSystem = flake-utils.lib.eachDefaultSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          formatter = pkgs.nixpkgs-fmt;
+          devShell = import ./shell.nix { inherit pkgs; };
+        });
     in
     nixpkgs.lib.recursiveUpdate perSystem {
       nixosConfigurations = {

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
-{ system, nixpkgs }:
-let pkgs = nixpkgs.legacyPackages.${system};
-in
+{ pkgs ? import <nixpkgs> { } }:
+
 pkgs.mkShell {
   name = "nix-config-dev";
   buildInputs = with pkgs; [


### PR DESCRIPTION
This PR rearranges how the development shell is defined to be able to
use it with both Flakes (`nix develop`) and the classic nix-shell.