### PR TITLE
Add headless home-manager target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,14 @@
           system
           revision;
       };
+      mkHome = import ./lib/mk-home.nix {
+        inherit
+          myLib
+          overlays
+          home-manager
+          agenix
+          catppuccin;
+      };
       forAllSystems = flake-utils.lib.eachDefaultSystem
         (system:
           let
@@ -106,6 +114,13 @@
         iso = mkISO;
         vm = mkNixOS "vm";
         fw16 = mkNixOS "fw16";
+      };
+      homeConfigurations = {
+        "headless-x86_64" = mkHome "pdalpra" [ "headless" ] "x86_64-linux";
+        "headless-aarch64" = mkHome "pdalpra" [ "headless" ] "aarch64-linux";
+      };
+      lib = {
+        inherit mkHome;
       };
     };
 }

--- a/home/modules/cli/terminal.nix
+++ b/home/modules/cli/terminal.nix
@@ -1,6 +1,6 @@
-_:
+{ lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   catppuccin.kitty.enable = true;
 
   programs.kitty = {

--- a/home/modules/dev/docker.nix
+++ b/home/modules/dev/docker.nix
@@ -1,6 +1,6 @@
-_:
+{ lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.sessionVariables = {
     DOCKER_SCAN_SUGGEST = "false";
   };

--- a/home/modules/editors/intellij.nix
+++ b/home/modules/editors/intellij.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home = {
     packages = with pkgs; [
       unstable.jetbrains.idea-ultimate

--- a/home/modules/editors/vscode.nix
+++ b/home/modules/editors/vscode.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   programs.vscode = {
     enable = true;
     package = pkgs.unstable.vscode;

--- a/home/modules/media/audio.nix
+++ b/home/modules/media/audio.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, lib, config, ... }:
 
 let
   # TODO: move it wav-converter repo as a flake
@@ -15,7 +15,7 @@ let
     };
   };
 in
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.packages = with pkgs; [
     android-file-transfer
     asunder

--- a/home/modules/media/video.nix
+++ b/home/modules/media/video.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.packages = with pkgs; [
     mupdf
     vlc

--- a/home/modules/misc/fonts.nix
+++ b/home/modules/misc/fonts.nix
@@ -1,4 +1,4 @@
-{ config, myLib, ... }:
+{ config, lib, myLib, ... }:
 
 let
   home = config.home.homeDirectory;
@@ -19,4 +19,4 @@ let
     };
   };
 in
-myLib.mergeAll (map toSecret fontNames)
+lib.mkIf (!builtins.elem "headless" config.profile) (myLib.mergeAll (map toSecret fontNames))

--- a/home/modules/misc/security.nix
+++ b/home/modules/misc/security.nix
@@ -1,7 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
-
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.packages = with pkgs; [
     _1password-gui
     yubikey-manager

--- a/home/modules/web/apps.nix
+++ b/home/modules/web/apps.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.packages = with pkgs; [
     protonvpn-gui
     electron-mail

--- a/home/modules/web/browser.nix
+++ b/home/modules/web/browser.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   programs = {
     chromium = {
       enable = true;

--- a/home/modules/web/chat.nix
+++ b/home/modules/web/chat.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   home.packages = with pkgs; [
     discord
     whatsapp-for-linux

--- a/home/modules/wm/dunst.nix
+++ b/home/modules/wm/dunst.nix
@@ -1,6 +1,6 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   catppuccin.dunst.enable = true;
 
   home.packages = with pkgs; [

--- a/home/modules/wm/polybar.nix
+++ b/home/modules/wm/polybar.nix
@@ -16,7 +16,7 @@ let
     padding-right = 1;
   };
 in
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   catppuccin.polybar.enable = true;
 
   # Ensures that the polybar logs folder is created

--- a/home/modules/wm/rofi.nix
+++ b/home/modules/wm/rofi.nix
@@ -1,6 +1,6 @@
-{ pkgs, config, ... }:
+{ pkgs, lib, config, ... }:
 
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   catppuccin.rofi.enable = true;
 
   home.file."${config.xdg.configHome}/rofimoji.rc" = {

--- a/home/modules/wm/screenlocker.nix
+++ b/home/modules/wm/screenlocker.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 let
   xsecurelock =
     pkgs.xsecurelock.overrideAttrs (previous: {
@@ -20,7 +20,7 @@ let
       '';
     });
 in
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   # Restarts xss-lock automatically
   home.activation = {
     restartXssLock = lib.hm.dag.entryAfter [ "writeBoundary" ]

--- a/home/modules/wm/xmonad.nix
+++ b/home/modules/wm/xmonad.nix
@@ -14,7 +14,7 @@ let
     ];
   };
 in
-{
+lib.mkIf (!builtins.elem "headless" config.profile) {
   catppuccin.cursors.enable = true;
 
   home = {

--- a/lib/mk-home.nix
+++ b/lib/mk-home.nix
@@ -1,0 +1,25 @@
+{ myLib
+, overlays
+, home-manager
+, agenix
+, catppuccin
+}: username: profile: system:
+
+let
+  pkgs = overlays system;
+in
+home-manager.lib.homeManagerConfiguration {
+  inherit pkgs;
+  extraSpecialArgs = { inherit myLib; };
+  modules = [
+    ../modules/common/profile.nix
+    agenix.homeManagerModules.default
+    catppuccin.homeModules.catppuccin
+    {
+      home.username = username;
+      home.homeDirectory = "/home/${username}";
+      inherit profile;
+    }
+    ../home/home.nix
+  ];
+}

--- a/modules/common/profile.nix
+++ b/modules/common/profile.nix
@@ -2,19 +2,20 @@
 
 {
   options.profile = with lib; with types; mkOption {
-    description = "Usage profile for this machine. Must be set.";
-    default = null;
-    type = nullOr (enum [
+    description = "Usage profile tags for this machine. Must be non-empty.";
+    default = [ ];
+    type = listOf (enum [
       "personal"
       "work"
+      "headless"
     ]);
   };
 
   config = {
     assertions = [
       {
-        assertion = config.profile != null;
-        message = "Profile must be set";
+        assertion = config.profile != [ ];
+        message = "Profile must be non-empty";
       }
     ];
   };

--- a/system/machines/fw16/configuration.nix
+++ b/system/machines/fw16/configuration.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, config, hardware, ... }:
 
 {
-  profile = "personal";
+  profile = [ "personal" ];
 
   imports = [
     hardware.framework-16-7040-amd

--- a/system/machines/vm/configuration.nix
+++ b/system/machines/vm/configuration.nix
@@ -1,6 +1,6 @@
 {
 
-  profile = "personal";
+  profile = [ "personal" ];
 
   # Required by ZFS
   networking.hostId = "fcd4a364";


### PR DESCRIPTION
Introduce a standalone homeConfigurations entry usable on a Linux host via SSH, without requiring NixOS or full system control. Two arch variants are exposed: headless-x86_64 and headless-aarch64.

Generalize the existing profile module option from a single string to a list of tags (listOf (enum [...])) and add "headless" to the enum. Existing machine configs migrate from `profile = "personal";` to `profile = [ "personal" ];`.

GUI-only home modules wrap their bodies in
  lib.mkIf (!builtins.elem "headless" config.profile)
so they no-op on headless while remaining unchanged for the personal/work profiles.

Expose mkHome via flake outputs so external wrapper flakes can build their own homeConfigurations on top of this one without forking — handy when running on a host whose user differs from the public default.